### PR TITLE
add AOD to paid license types and add WITH_ADS to markings of both AOD types

### DIFF
--- a/resources/lib/const.py
+++ b/resources/lib/const.py
@@ -192,13 +192,17 @@ CONST = {
         'LICENSE_TYPES': {
             'FREE': {
                 'AVOD': {
-                    'MARKING_TYPES': ['JOYN_ORIGINAL', 'HD', 'PREVIEW']
+                    'MARKING_TYPES': ['JOYN_ORIGINAL', 'HD', 'PREVIEW', 'WITH_ADS']
                 }
             },
             'PAID': {
                 'SVOD': {
                     'SUBSCRIPTION_TYPE': 'hasActivePlus',
                     'MARKING_TYPES': ['PREMIUM', 'HD', 'JOYN_ORIGINAL', 'PLUS', 'PREVIEW'],
+                },
+                'AVOD': {
+                    'SUBSCRIPTION_TYPE': 'hasActivePlus',
+                    'MARKING_TYPES': ['PREMIUM', 'HD', 'JOYN_ORIGINAL', 'PLUS', 'PREVIEW', 'WITH_ADS'],
                 },
             },
         },

--- a/resources/lib/lib_joyn.py
+++ b/resources/lib/lib_joyn.py
@@ -177,13 +177,11 @@ class lib_joyn(Singleton):
 						for marking in markings:
 							if not marking in CONST['LICENSE_TYPES']['FREE'][license_type]['MARKING_TYPES']:
 								found_all_markings = False
-								break
-
 						if found_all_markings is True:
 							return True
 					else:
 						return True
-				elif license_type in CONST['LICENSE_TYPES']['PAID'].keys():
+				if license_type in CONST['LICENSE_TYPES']['PAID'].keys():
 					if self.get_account_subscription_config(CONST['LICENSE_TYPES']['PAID'][license_type]['SUBSCRIPTION_TYPE']) is True:
 						if len(markings) > 0:
 							found_all_markings = True


### PR DESCRIPTION
add AOD to paid license types and add WITH_ADS to markings of both AOD types

(as discussed on kodinerds)